### PR TITLE
Colorize links to unwritten articles

### DIFF
--- a/config.php
+++ b/config.php
@@ -113,6 +113,13 @@ define('EDIT_ROWS', 18);
 
 define('AUTOLINK_PAGE_TITLES', false);
 
+// COLORIZE_MISSING_PAGES
+//
+// Automatically highlights as red links, any linked pages which are
+// not yet written. Existing but blank pages are not colorized. This
+// might degrade performance if you have thousands of links on a page.
+
+define('COLORIZE_MISSING_PAGES', true);
 
 // -----------------------------
 // Security and session settings

--- a/index.css
+++ b/index.css
@@ -149,6 +149,10 @@ a.tool {
 	color: #eeeeee;
 }
 
+a.missing-link {
+	color: #ba0000;
+}
+
 input.tool {
 	font-size: 11px;
 	color: #000000;

--- a/index.php
+++ b/index.php
@@ -84,7 +84,13 @@ if ( REQUIRE_PASSWORD && !isset($_SESSION['password']) )
 
 function _handle_links($match)
 {
-	return "<a href=\"" . SELF . VIEW . "/" . htmlentities($match[1]) . "\">" . htmlentities($match[1]) . "</a>";
+	$link_page = $match[1];
+	$link_filename = PAGES_PATH . "/$link_page.txt";
+	$link_page_exists = file_exists($link_filename);
+	if ($link_page_exists)
+		return "<a href=\"" . SELF . VIEW . "/" . htmlentities($link_page) . "\">" . htmlentities($link_page) . "</a>";
+	else
+		return "<a href=\"" . SELF . VIEW . "/" . htmlentities($link_page) . "\" class=\"missing-link\">" . htmlentities($link_page) . "</a>";
 }
 
 

--- a/index.php
+++ b/index.php
@@ -84,13 +84,18 @@ if ( REQUIRE_PASSWORD && !isset($_SESSION['password']) )
 
 function _handle_links($match)
 {
-	$link_page = $match[1];
-	$link_filename = PAGES_PATH . "/$link_page.txt";
-	$link_page_exists = file_exists($link_filename);
+	$link = $match[1];
+	if ( COLORIZE_MISSING_PAGES ) {
+		$link_page = sanitizeFilename($link);
+		$link_filename = PAGES_PATH . "/$link_page.txt";
+		$link_page_exists = file_exists($link_filename);
+	} else {
+		$link_page_exists = true;
+	}
 	if ($link_page_exists)
-		return "<a href=\"" . SELF . VIEW . "/" . htmlentities($link_page) . "\">" . htmlentities($link_page) . "</a>";
+		return "<a href=\"" . SELF . VIEW . "/" . htmlentities($link) . "\">" . htmlentities($link) . "</a>";
 	else
-		return "<a href=\"" . SELF . VIEW . "/" . htmlentities($link_page) . "\" class=\"missing-link\">" . htmlentities($link_page) . "</a>";
+		return "<a href=\"" . SELF . VIEW . "/" . htmlentities($link) . "\" class=\"missing-link\">" . htmlentities($link) . "</a>";
 }
 
 


### PR DESCRIPTION
This is a form of dead link detection, called "red links" in MediaWiki. Links to unwritten articles are displayed in another color (red). This makes it easy for wiki authors to spot articles which need written without clicking through, or spelling errors.

I believe this code is correct, but I noticed that there are four places you generate links (also auto-linking existing filenames if that's enabled, as well as two "display all" options). It could be worth combining them all?